### PR TITLE
Fix backend Docker image tag

### DIFF
--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -17,7 +17,7 @@ RUN ./gradlew clean build -x test
 RUN find . -name "*-plain.jar" -type f -delete
 
 # ===== Stage 2: Runtime – Minimaler JRE Container =====
-FROM openjdk:26-slim
+FROM openjdk:21-slim
 WORKDIR /app
 
 # Kopiere das erstellte Jar in den Runtime-Container


### PR DESCRIPTION
## Summary
- update the runtime stage of the backend Dockerfile to use the available openjdk:21-slim image

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69138f08e0b4832db522eb9e4ce5d6ca)