### PR TITLE
Fix backend runtime Docker base image

### DIFF
--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -17,7 +17,7 @@ RUN ./gradlew clean build -x test
 RUN find . -name "*-plain.jar" -type f -delete
 
 # ===== Stage 2: Runtime – Minimaler JRE Container =====
-FROM openjdk:26-slim
+FROM eclipse-temurin:21-jre
 WORKDIR /app
 
 # Kopiere das erstellte Jar in den Runtime-Container


### PR DESCRIPTION
## Summary
- replace the unavailable `openjdk:26-slim` runtime image with the supported `eclipse-temurin:21-jre` tag to unblock Docker builds

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69138f08e0b4832db522eb9e4ce5d6ca)